### PR TITLE
Prioridad de carga a script  BASE64 y optimizado + Entrega FINAL

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -13,6 +13,8 @@
 </head>
 
 <body class="bg-body bg-gradient">
+  <!-- Carga de Script BASE64-->
+  <script src="js/base64-loader.js"></script>
 
   <header class="navbar navbar-expand-lg bg-body-tertiary text-body sticky-top">
     <div class="container">
@@ -129,8 +131,7 @@
 
 
   <script src="bootstrap-5.3.8-dist/js/bootstrap.bundle.min.js"></script>
-  <script type="module" src="js/tema.js"></script>
-  <script src="js/base64-loader.js"></script>
+  <script type="module" src="js/tema.js"></script>  
   <script>
   document.addEventListener("DOMContentLoaded", () => {
     const form = document.querySelector("form");

--- a/especialidades.html
+++ b/especialidades.html
@@ -15,6 +15,8 @@
 
   <!-- STOP de Sesión -->
   <script src="js/verificarSesion.js"></script>
+  <!-- Carga de Script BASE64-->
+  <script src="js/base64-loader.js"></script>
 
   <header class="navbar navbar-expand-lg bg-body-tertiary text-body shadow-sm sticky-top">
     <div class="container">

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
 </head>
 
 <body class="bg-body bg-gradient">
+  <!-- Carga de Script BASE64-->
+  <script src="js/base64-loader.js"></script>
 
   <header class="navbar navbar-expand-lg bg-body-tertiary text-body sticky-top">
     <div class="container">
@@ -154,6 +156,5 @@
   <script type="module" src="js/medicosindex.js"></script>
   <script type="module" src="js/obrasindex.js"></script>
   <script type="module" src="js/tema.js"></script>
-  <script src="js/base64-loader.js"></script>
 </body>
 </html>

--- a/iniciosesion.html
+++ b/iniciosesion.html
@@ -12,6 +12,9 @@
 </head>
 
 <body class="bg-light d-flex align-items-center justify-content-center vh-100">
+    <!-- Carga de Script BASE64-->
+    <script src="js/base64-loader.js"></script>
+    
     <div class="d-flex flex-column align-items-center justify-content-center min-vh-100">
         <img data-src="img/logo2.png" alt="Logo Clínica" class="img-fluid mb-4" style="max-width: 250px; height: auto;">
 
@@ -40,7 +43,6 @@
         </div>
     </div>
     <script src="js/iniciosesion.js"></script>
-    <script src="js/base64-loader.js"></script>
 </body>
 
 </html>

--- a/institucional.html
+++ b/institucional.html
@@ -13,7 +13,8 @@
 </head>
 
 <body class="bg-body bg-gradient">
-
+  <!-- Carga de Script BASE64-->
+  <script src="js/base64-loader.js"></script>
   <header class="navbar navbar-expand-lg bg-body-tertiary text-body sticky-top">
     <div class="container">
 
@@ -145,7 +146,6 @@
 
   <script src="bootstrap-5.3.8-dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="js/tema.js"></script>
-  <script src="js/base64-loader.js"></script>
 </body>
 
 </html>

--- a/js/base64-loader.js
+++ b/js/base64-loader.js
@@ -1,20 +1,19 @@
-document.addEventListener("DOMContentLoaded", async () => {
+// Carga rápido al llegar al SCRITPT
+(async () => {
   try {
     const res = await fetch("js/imagenes_base64.json");
     const data = await res.json();
 
-
     window.reemplazarImagenes = () => {
       document.querySelectorAll("img[data-src]").forEach(img => {
         let src = img.getAttribute("data-src")
-          ?.replace(/^\.?\/*/, "")   
-          ?.replace(/^img\//, "");   
+          ?.replace(/^\.?\/*/, "")
+          ?.replace(/^img\//, "");
 
         if (data[src]) {
           img.src = data[src];
           console.log(`Reemplazada desde JSON: ${src}`);
         } else {
-          
           if (!src.startsWith("data:image")) {
             img.src = img.getAttribute("data-src");
           }
@@ -28,7 +27,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           ?.replace(/^img\//, "");
         if (data[src]) {
           favicon.href = data[src];
-          console.log(`Favicon reemplazado correctamente: ${src}`);
+          console.log(`Favicon reemplazado: ${src}`);
         }
       }
     };
@@ -38,4 +37,4 @@ document.addEventListener("DOMContentLoaded", async () => {
   } catch (err) {
     console.error("Error cargando imágenes Base64:", err);
   }
-});
+})();

--- a/medicos.html
+++ b/medicos.html
@@ -15,6 +15,8 @@
 
   <!-- STOP de sesión -->
   <script src="js/verificarSesion.js"></script>
+    <!-- Carga de Script BASE64-->
+  <script src="js/base64-loader.js"></script>
 
   <header class="navbar navbar-expand-lg bg-body-tertiary text-body shadow-sm sticky-top">
     <div class="container">
@@ -161,6 +163,5 @@
       window.location.href = "iniciosesion.html";
     }
   </script>
-  <script src="js/base64-loader.js"></script>
 </body>
 </html>

--- a/obras.html
+++ b/obras.html
@@ -15,6 +15,8 @@
 
   <!-- STOP de sesión -->
   <script src="js/verificarSesion.js"></script>
+  <!-- Carga de Script BASE64-->
+  <script src="js/base64-loader.js"></script>
 
   <header class="navbar navbar-expand-lg bg-body-tertiary text-body shadow-sm sticky-top">
     <div class="container">
@@ -138,7 +140,6 @@
       window.location.href = "iniciosesion.html";
     }
   </script>
-  <script src="js/base64-loader.js"></script>
 
 </body>
 </html>

--- a/paneladmin.html
+++ b/paneladmin.html
@@ -16,6 +16,8 @@
 
   <!-- STOP de Sesión -->
   <script src="js/verificarSesion.js"></script>
+    <!-- Carga de Script BASE64-->
+  <script src="js/base64-loader.js"></script>
 
   <header class="navbar navbar-expand-lg bg-body text-body shadow-sm sticky-top">
     <div class="container">
@@ -157,6 +159,5 @@
       window.location.href = "iniciosesion.html";
     }
   </script>
-  <script src="js/base64-loader.js"></script>
 </body>
 </html>

--- a/reservasadmin.html
+++ b/reservasadmin.html
@@ -16,6 +16,8 @@
 
   <!-- STOP de sesión -->
   <script src="js/verificarSesion.js"></script>
+    <!-- Carga de Script BASE64-->
+  <script src="js/base64-loader.js"></script>
 
 
   <header class="navbar navbar-expand-lg bg-body text-body shadow-sm sticky-top">
@@ -77,7 +79,6 @@
 
   <script src="bootstrap-5.3.8-dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="js/reservasadmin.js"></script>
-  <script src="js/base64-loader.js"></script>
 
   <script>
     function logout() {

--- a/turnero.html
+++ b/turnero.html
@@ -15,6 +15,9 @@
 </head>
 
 <body class="bg-body bg-gradient">
+    <!-- Carga de Script BASE64-->
+    <script src="js/base64-loader.js"></script>
+    
     <header class="navbar navbar-expand-lg bg-body-tertiary text-body sticky-top">
         <div class="container">
             <a class="navbar-brand d-flex align-items-center">
@@ -140,6 +143,5 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script type="module" src="js/turnero.js"></script>
     <script type="module" src="js/tema.js"></script>
-    <script src="js/base64-loader.js"></script>
 </body>
 </html>

--- a/turnosadmin.html
+++ b/turnosadmin.html
@@ -15,6 +15,8 @@
 
   <!-- STOP de Sesión -->
   <script src="js/verificarSesion.js"></script>
+  <!-- Carga de Script BASE64-->
+  <script src="js/base64-loader.js"></script>
 
 
   <header class="navbar navbar-expand-lg bg-body text-body shadow-sm sticky-top">
@@ -127,6 +129,5 @@
       window.location.href = "iniciosesion.html";
     }
   </script>
-  <script src="js/base64-loader.js"></script>
 </body>
 </html>

--- a/usuariosadmin.html
+++ b/usuariosadmin.html
@@ -15,6 +15,8 @@
 
   <!-- STOP de Sesión -->
   <script src="js/verificarSesion.js"></script>
+  <!-- Carga de Script BASE64-->
+  <script src="js/base64-loader.js"></script>
 
 
   <header class="navbar navbar-expand-lg bg-body text-body shadow-sm sticky-top">
@@ -85,6 +87,5 @@
       window.location.href = "iniciosesion.html";
     }
   </script>
-  <script src="js/base64-loader.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Se le dio prioridad al script de carga del base64 para que no demore tanto la carga de las imagenes, si de pronto se ingresa en un navegador nuevo. Se coloco el script de forma inmediata después del BODY no en el final como lo habíamos puesto. 